### PR TITLE
Fix link to documentation references

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
This pull request makes a small fix to the documentation sidebar by correcting a filename typo. The link to the documentation references page now points to the correct file.